### PR TITLE
update tool to use jtag uart instead of physical uart

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,10 @@ sudo ./prog_spi.sh -i <boot.bin to program into OSPI> -d versal_eval -b <boot.bi
 
 ## Known issues and Debug Tips
 
-* Current version of script depends on physical uart to interact with u-boot. the UART may not always enumerate to the same /dev/ttyUSB*. to overwrite it in the case that it enumerates to a different device than what the script assumed, use -p flag to overwrite uart device location, such as:
-
-``` sudo ./prog_ospi.sh -i <boot.bin> -d rhino -p /dev/ttyUSB0```
-
 * If the script is stopped during execution, Versal may get in an indeterminate state. If you have issues running the script subsequently, power cycle the platform (not just a Ryzen reboot) and try the script again.
 
 * You may ignore the "rlwrap" warnings.
+
 
 # License
 (C) Copyright 2024, Advanced Micro Devices Inc.\

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Embedded Platform BootFW Update Tool
 
-NOTE: Stable version of this utility with corresponding readme and bin file are in the release area.
+## NOTE: Stable version of this utility with corresponding readme and bin folder are in the release area. This readme corresponds to V2.0 release.
 
 This repository provides a utility to update AMD ACAP's (Adaptive Compute Acceleration Platform aka Adaptive SoC) flash device (OSPI or QSPI) with boot firmware in supported platforms. The current supported platforms are:
 
@@ -14,6 +14,10 @@ This repository provides a utility to update AMD ACAP's (Adaptive Compute Accele
 ### On Embedded+ based platforms
 
 Current Embedded+ platforms have a Versal and a Ryzen device. Versal firmware update expects that Ryzen is already running Ubuntu, as the firmware update would be performed from Ryzen. Therefore, all the components required to either log onto Ryzen Ubuntu via keyboard+mouse+monitor, network access and ssh, is required and not listed below.
+
+On Embedded Plus platform, there are capabilities to set bootmode to JTAG and reset the board through FTDI GPIO and that is being leveraged by the script.
+
+On Rhino platform, there isnt a way to set bootmode using FTDI GPIO. Therefore, if there's program already in OSPI that prevents subsequent programs to access OSPI or DDR, script will not work. In that case, set bootmode to JTAG on the board using physical jumpers, power cycle, and then use this utility again.
 
 ### On Kria platforms
 
@@ -51,7 +55,11 @@ These are the steps to install HW_server if none of them are installed:
       sudo reboot
       ```
 
-Lastly, clone this repo on Ryzen's Ubuntu.  Find ```prog_spi.sh``` in the cloned folder. Then look in the "tag" area of this repo, choose the latest release, download the ```bin.zip``` files from the release, unzip and place the bin/ folder in the same folder as ```prog_spi.sh```. (You may also download source code from the tagged release instead of cloning it).
+### (all platforms) Download  and set up Utility
+
+Lastly, go to [Releases](https://github.com/Xilinx/embpf-bootfw-update-tool/releases), find the latest release (V2.0), download it's "Source code" and "bin.zip". Unzip them in your Linux host.  Find ```prog_spi.sh``` in the source code folder. Then place the bin/ folder from bin.zip in the same folder as ```prog_spi.sh```.
+
+*** Important! You must download and use the bin.zip file from release area for Kria and embedded plus platforms. Do not copy your own boot.bin files to the bin/ folder. Do not use the BOOT*.bin files in bin/ folder as an input to -i . They are special binary files created to boot u-boot with jtag uart instead of physical uart ***
 
 Make ```prog_spi.sh``` executable:
 
@@ -71,7 +79,6 @@ Usage: ./prog_spi.sh -i <path_to_boot.bin> -d <board_type>
     -d <board>     : Board type.  Supported values
                      embplus, rhino, kria_k26, kria_k24c,
                      kria_k24i, versal_eval
-    -p <port>      : Optional argument to override serial port
     -b <boot_file> : Optional argument to override programming boot.bin
     -h             : help
 ```
@@ -100,6 +107,14 @@ sudo ./prog_spi.sh -i <boot.bin> -d kria_k24i
 
 When the script finishes (in about 4 minutes), the flash will have been updated with <boot.bin>.
 
+### Advanced users
+
+For other systems, you may create your own boot.bin file that boots u-boot over jtag uart, and then use -b <boot_file> to pass in the boot.bin. The u-boot created must use jtag uart instead of physical uart, and have access to DDR and OSPI. The command would look like below for a Versal based board:
+
+```
+sudo ./prog_spi.sh -i <boot.bin to program into OSPI> -d versal_eval -b <boot.bin that uses jtag uart>
+```
+
 ## Known issues and Debug Tips
 
 * Current version of script depends on physical uart to interact with u-boot. the UART may not always enumerate to the same /dev/ttyUSB*. to overwrite it in the case that it enumerates to a different device than what the script assumed, use -p flag to overwrite uart device location, such as:
@@ -107,8 +122,6 @@ When the script finishes (in about 4 minutes), the flash will have been updated 
 ``` sudo ./prog_ospi.sh -i <boot.bin> -d rhino -p /dev/ttyUSB0```
 
 * If the script is stopped during execution, Versal may get in an indeterminate state. If you have issues running the script subsequently, power cycle the platform (not just a Ryzen reboot) and try the script again.
-
-* Uncluttered uart output from Versal is also captured in uart_output.log in the same folder. You may read it for debugging purposes.
 
 * You may ignore the "rlwrap" warnings.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This repository provides a utility to update AMD ACAP's (Adaptive Compute Accele
 
 * [Embedded+](https://www.amd.com/en/products/embedded/embedded-plus.html) products
    * [Edge+ VPR-4616](https://www.sapphiretech.com/en/commercial/edge-plus-vpr_4616) Versal OSPI update
-* Rhino Versal OSPI update
+   * Rhino Versal OSPI update
 * Kria production SOM QSPI update (K26, K24c, K24i)
+* Versal Eval board VHK158 Versal OSPI update
 
 ## External Components and one time setup Required
 
@@ -18,6 +19,10 @@ Current Embedded+ platforms have a Versal and a Ryzen device. Versal firmware up
 On Embedded Plus platform, there are capabilities to set bootmode to JTAG and reset the board through FTDI GPIO and that is being leveraged by the script.
 
 On Rhino platform, there isnt a way to set bootmode using FTDI GPIO. Therefore, if there's program already in OSPI that prevents subsequent programs to access OSPI or DDR, script will not work. In that case, set bootmode to JTAG on the board using physical jumpers, power cycle, and then use this utility again.
+
+### On Versal Evaluation platforms
+
+On Versal eval platforms such as VHK158, there's a system controller that has access to Versal. This utility can be run from the system controller to update the OSPI.
 
 ### On Kria platforms
 
@@ -105,11 +110,16 @@ sudo ./prog_spi.sh -i <boot.bin> -d kria_k24c
 sudo ./prog_spi.sh -i <boot.bin> -d kria_k24i
 ```
 
+for VHK158, use -d versal_eval and script will automatically check if it is running on VHK158 system controller:
+```
+sudo ./prog_spi.sh -i <boot.bin> -d versal_eval
+```
+
 When the script finishes (in about 4 minutes), the flash will have been updated with <boot.bin>.
 
 ### Advanced users
 
-For other systems, you may create your own boot.bin file that boots u-boot over jtag uart, and then use -b <boot_file> to pass in the boot.bin. The u-boot created must use jtag uart instead of physical uart, and have access to DDR and OSPI. The command would look like below for a Versal based board:
+For other versal-based systems, you may create your own boot.bin file that boots u-boot over jtag uart, and then use -b <boot_file> to pass in the boot.bin. The u-boot created must use jtag uart instead of physical uart, and have access to DDR and OSPI. The command would look like below for a Versal based board:
 
 ```
 sudo ./prog_spi.sh -i <boot.bin to program into OSPI> -d versal_eval -b <boot.bin that uses jtag uart>
@@ -117,7 +127,9 @@ sudo ./prog_spi.sh -i <boot.bin to program into OSPI> -d versal_eval -b <boot.bi
 
 ## Known issues and Debug Tips
 
-* If the script is stopped during execution, Versal may get in an indeterminate state. If you have issues running the script subsequently, power cycle the platform (not just a Ryzen reboot) and try the script again.
+* If the script is stopped during execution, Versal may get in an indeterminate state. If you have issues running the script subsequently, power cycle the platform (not just a reboot) and try the script again.
+
+* The tool will attempt to put the Versal in JTAG bootmode - via FTDI if that is available on the platform and always via XSDB. If the platform is in OSPI mode and OSPI already contains boot code that prevents access to DDR and OSPI from the utility - you may need to change platform to JTAG bootmode via hardware jumpers to prevent OSPI code from executing.
 
 * You may ignore the "rlwrap" warnings.
 

--- a/prog_spi.sh
+++ b/prog_spi.sh
@@ -223,11 +223,7 @@ fi
 
 # Run the xsdb script to start jtag uart and capture the socket port
 socket_file=tmp.socket
-if [ -f "$socket_file" ]; then
-    rm "$socket_file"
-fi
 $XSDB ${device_type}/uart.tcl   &> $socket_file &
-
 rt=0
 while [ "$SOCK" == "" ] && [ $rt -lt 10 ]; do
    SOCK=$(tail -n 1 $socket_file)

--- a/prog_spi.sh
+++ b/prog_spi.sh
@@ -222,11 +222,20 @@ fi
 
 
 # Run the xsdb script to start jtag uart and capture the socket port
-$XSDB ${device_type}/uart.tcl   &> tmp &
-sleep 1
-SOCK=$(tail -n 1 tmp) 
-echo $sock
- 
+socket_file=tmp.socket
+if [ -f "$socket_file" ]; then
+    rm "$socket_file"
+fi
+$XSDB ${device_type}/uart.tcl   &> $socket_file &
+
+rt=0
+while [ "$SOCK" == "" ] && [ $rt -lt 10 ]; do
+   SOCK=$(tail -n 1 $socket_file)
+   rt=$(( rt + 1 ))
+   sleep 1
+done
+echo $SOCK
+
 
 # Check if the socket was created successfully
 if [[ ! "$SOCK" =~ ^[0-9]+$ ]]; then

--- a/prog_spi.sh
+++ b/prog_spi.sh
@@ -310,8 +310,8 @@ echo
 cleanup
 
 if $jtag_mux; then
-    gpioget $(gpiofind SYSCTLR_JTAG_S0)
-    gpioget $(gpiofind SYSCTLR_JTAG_S1)
+    gpioget $(gpiofind SYSCTLR_JTAG_S0) >/dev/null
+    gpioget $(gpiofind SYSCTLR_JTAG_S1) >/dev/null
 fi
 
 echo

--- a/prog_spi.sh
+++ b/prog_spi.sh
@@ -16,7 +16,6 @@ cleanup(){
     exec {COPROC[0]}>&-
     exec {COPROC[1]}>&-
     kill "${XSDB_PID}"
-    pkill  -f "hw_server"
     sleep 1
 }
 # Function to send strings to the JTAG UART
@@ -59,12 +58,14 @@ match_jtaguart_output() {
   exit 1  # No match found
 }
 
-if command -v xsdb >/dev/null 2>&1; then
-    echo "xsdb is in PATH: $(command -v xsdb)"
-elif [ -f /etc/profile.d/xsdb-variables.sh ]; then
+if [ -f /etc/profile.d/xsdb-variables.sh ]; then
     source /etc/profile.d/xsdb-variables.sh
     XSDB_PATH=$XILINX_VITIS
-    XSDB=$XILINX_VITIS/xsdb
+fi
+
+if command -v xsdb >/dev/null 2>&1; then
+    echo "xsdb is in PATH: $(command -v xsdb)"
+    XSDB=$(which xsdb)
 else 
     # Look for xsdb in the system and filter paths containing "bin/xsdb"
     XSDB_PATH=$(find /usr /opt /tools /home -iname xsdb 2>/dev/null | grep "/bin/xsdb" | head -n 1)
@@ -86,7 +87,6 @@ else
         exit 1
     fi
 fi
-
 
 
 detect_board() {

--- a/prog_spi.sh
+++ b/prog_spi.sh
@@ -255,12 +255,10 @@ send_to_jtaguart " "
 sleep 1
 
 
-##temporary removal to make debug faster $XSDB ${device_type}/download_data.tcl $path_to_boot_bin
+$XSDB ${device_type}/download_data.tcl $path_to_boot_bin
 
-#echo -en "sf probe 0x0 0x0 0x0\r" > $uart_dev
 send_to_jtaguart "sf probe 0x0 0x0 0x0"
 
-#wait_for_uart_output "Detected"
 match_jtaguart_output "Detected" 10
 
 echo
@@ -270,10 +268,9 @@ echo
 bin_size=$(stat --printf="%s" $path_to_boot_bin)
 bin_size_hex=$(printf "%08x" $bin_size)
 
-#echo -en "sf update 0x80000 0x0 $bin_size_hex\r" > "$uart_dev"
 send_to_jtaguart "sf update 0x80000 0x0 $bin_size_hex"
 
-#wait_for_uart_output "written"
+
 match_jtaguart_output "written" 600
 echo
 echo "SPI written successfully."

--- a/prog_spi.sh
+++ b/prog_spi.sh
@@ -16,6 +16,8 @@ cleanup(){
     exec {COPROC[0]}>&-
     exec {COPROC[1]}>&-
     kill "${XSDB_PID}"
+    ps ax | grep xsdb | grep uart.tcl | awk '{print $1}' | xargs --no-run-if-empty kill -9 2>/dev/null
+
     sleep 1
 }
 # Function to send strings to the JTAG UART

--- a/versal/download_data.tcl
+++ b/versal/download_data.tcl
@@ -9,4 +9,5 @@ after 2000
 puts "downloading flash content to DDR"
 dow -force -data [lindex $argv 0]  0x80000
 puts "content downloaded to DDR, prepare to write to flash"
-
+disconnect
+exit

--- a/versal/embplus_jtag_porb.py
+++ b/versal/embplus_jtag_porb.py
@@ -7,13 +7,50 @@
 
 
 import sys
+import subprocess
+import re
 
 from pyftdi.gpio import (GpioAsyncController,
                          GpioSyncController,
                          GpioMpsseController)
 
+
+def get_ftdi_url(target_label="VE2302", target_interface="/1"):
+    try:
+        # Run the command and capture output (without sudo)
+        result = subprocess.run(["ftdi_urls.py"], capture_output=True, text=True)
+        output = result.stdout
+
+        # Iterate through lines and look for the target device
+        for line in output.splitlines():
+            if target_label in line and target_interface in line:
+                match = re.search(r"(ftdi://ftdi:4232:[^/]+/1)", line)
+                if match:
+                    return match.group(1)  # Return the matching FTDI URL
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error running ftdi_urls.py: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+    
+    print("Error: No matching FTDI URL found.", file=sys.stderr)
+    sys.exit(1)
+    
+    return None
+
 if __name__ == "__main__":
-    ftdi_url = "ftdi://ftdi:4232:000000000000/1"
+
+
+    # Assign FTDI URL
+    ftdi_url = get_ftdi_url()
+
+    if ftdi_url:
+        print(f"FTDI URL: {ftdi_url}")
+    else:
+        print("No matching FTDI URL found. should not reach here")
+        sys.exit(1)
     
     gpio = GpioAsyncController()
     gpio.configure(ftdi_url, direction=0xC0)

--- a/versal/embplus_jtag_porb.py
+++ b/versal/embplus_jtag_porb.py
@@ -15,42 +15,14 @@ from pyftdi.gpio import (GpioAsyncController,
                          GpioMpsseController)
 
 
-def get_ftdi_url(target_label="VE2302", target_interface="/1"):
-    try:
-        # Run the command and capture output (without sudo)
-        result = subprocess.run(["ftdi_urls.py"], capture_output=True, text=True)
-        output = result.stdout
-
-        # Iterate through lines and look for the target device
-        for line in output.splitlines():
-            if target_label in line and target_interface in line:
-                match = re.search(r"(ftdi://ftdi:4232:[^/]+/1)", line)
-                if match:
-                    return match.group(1)  # Return the matching FTDI URL
-
-    except subprocess.CalledProcessError as e:
-        print(f"Error running ftdi_urls.py: {e}", file=sys.stderr)
-        sys.exit(1)
-    except Exception as e:
-        print(f"Error: {e}")
-        sys.exit(1)
-    
-    print("Error: No matching FTDI URL found.", file=sys.stderr)
-    sys.exit(1)
-    
-    return None
 
 if __name__ == "__main__":
 
+    with open("/sys/bus/usb/devices/3-1.4/serial", "r") as file:
+        serial = file.read().strip()
+    ftdi_url = f"ftdi://ftdi:4232:{serial}/1"
 
-    # Assign FTDI URL
-    ftdi_url = get_ftdi_url()
-
-    if ftdi_url:
-        print(f"FTDI URL: {ftdi_url}")
-    else:
-        print("No matching FTDI URL found. should not reach here")
-        sys.exit(1)
+    print(f"FTDI URL: {ftdi_url}")
     
     gpio = GpioAsyncController()
     gpio.configure(ftdi_url, direction=0xC0)

--- a/versal/embplus_jtag_porb.py
+++ b/versal/embplus_jtag_porb.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+###############################################################################
+# Copyright (c) 2022 - 2024, Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+
+import sys
+
+from pyftdi.gpio import (GpioAsyncController,
+                         GpioSyncController,
+                         GpioMpsseController)
+
+if __name__ == "__main__":
+    ftdi_url = "ftdi://ftdi:4232:000000000000/1"
+    
+    gpio = GpioAsyncController()
+    gpio.configure(ftdi_url, direction=0xC0)
+    gpio.write(0x80)
+    
+    gpio = GpioAsyncController()
+    gpio.configure(ftdi_url, direction=0x80)
+    gpio.write(0x80)
+
+

--- a/versal/jtag_boot.tcl
+++ b/versal/jtag_boot.tcl
@@ -12,4 +12,5 @@ device program [lindex $argv 0]
 puts "device program, u-boot started, prepare to program flash to DDR"
 con
 
-
+disconnect
+exit

--- a/versal/uart.tcl
+++ b/versal/uart.tcl
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2022 - 2024, Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+connect
+targets -set -nocase -filter {name =~ "Cortex-A72 #0*"}
+set sock [jtagterminal -start -socket]
+puts $sock ;
+vwait forever
+

--- a/zynqmp/jtag_boot.tcl
+++ b/zynqmp/jtag_boot.tcl
@@ -8,18 +8,20 @@
 
 puts stderr "Starting the script..."
 connect
-targets -set -nocase -filter {name =~ "PSU"}
-# update multiboot to ZERO
-mwr 0xffca0010 0x0
-# change boot mode to JTAG
-mwr 0xff5e0200 0x0100
-# reset
-rst -system
-after 2000
-targets -set -nocase -filter {name =~ "PSU"}
-mwr  0xffca0038 0x1ff
-targets -set -nocase -filter {name =~ "MicroBlaze PMU"}
 
+# required for jtag uart - setting jtag mode moved to uart.tcl
+#targets -set -nocase -filter {name =~ "PSU"}
+## update multiboot to ZERO
+#mwr 0xffca0010 0x0
+## change boot mode to JTAG
+#mwr 0xff5e0200 0x0100
+## reset
+#rst -system
+#after 2000
+#targets -set -nocase -filter {name =~ "PSU"}
+#mwr  0xffca0038 0x1ff
+
+targets -set -nocase -filter {name =~ "MicroBlaze PMU"}
 catch {stop}; after 1000
 puts stderr "INFO: Downloading zynqmp_pmufw ELF file to the target."
 dow -force "bin/pmufw.elf"

--- a/zynqmp/uart.tcl
+++ b/zynqmp/uart.tcl
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2022 - 2024, Advanced Micro Devices, Inc.  All rights reserved.
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+connect
+targets -set -nocase -filter {name =~ "Cortex-A53 #0*"}
+set sock [jtagterminal -start -socket]
+puts $sock ;
+vwait forever
+

--- a/zynqmp/uart.tcl
+++ b/zynqmp/uart.tcl
@@ -4,6 +4,18 @@
 ###############################################################################
 
 connect
+
+targets -set -nocase -filter {name =~ "PSU"}
+# update multiboot to ZERO
+mwr 0xffca0010 0x0
+# change boot mode to JTAG
+mwr 0xff5e0200 0x0100
+# reset
+rst -system
+after 2000
+targets -set -nocase -filter {name =~ "PSU"}
+mwr  0xffca0038 0x1ff
+
 targets -set -nocase -filter {name =~ "Cortex-A53 #0*"}
 set sock [jtagterminal -start -socket]
 puts $sock ;


### PR DESCRIPTION
the utility assumes that bin/ folder contains jtag uart boot files (rev 2.0 release bin.zip)
rave now uses FTDI GPIO to change to jtagboot mode and reset